### PR TITLE
don't always set `tooltip.keyBindingCommand`

### DIFF
--- a/lib/items/tool-bar-button-view.js
+++ b/lib/items/tool-bar-button-view.js
@@ -112,12 +112,6 @@ class ToolBarButtonView extends ToolBarItem {
       tooltip.placement = getTooltipPlacement();
     }
 
-    if (!tooltip.hasOwnProperty('keyBindingCommand') &&
-      typeof this.options.callback === 'string'
-    ) {
-      tooltip.keyBindingCommand = this.options.callback;
-    }
-
     this.subscriptions.add(atom.tooltips.add(this.element, tooltip));
   }
 


### PR DESCRIPTION
- Fixes #307 
- Almost doubles the speed of button creation (X2 faster)
- See https://github.com/suda/tool-bar/issues/307#issuecomment-641719848 for the reason

Button creation time:

**After**: 
![2020-06-10 00_01_00-Timecop — C__Users_yahyaaba_Documents_GitHub_JavaScript_tool-bar — Atom](https://user-images.githubusercontent.com/16418197/84228822-adca4580-aaad-11ea-8b01-47f080715ce1.jpg)

**Before**:
![image](https://user-images.githubusercontent.com/16418197/84226270-f2061780-aaa6-11ea-9778-ea9a52c7a4ed.png)

This is not shown in the loading time of `tool-bar` since other packages add buttons using the service, but instead, it can be easily measured using `window.performance.now()`